### PR TITLE
Fix yfinance version pin and migrate scoring to polars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-yfinance==0.2.36
+yfinance==1.3.0
 sqlalchemy==2.0.27
 pandas==2.2.1
 polars==1.30.0


### PR DESCRIPTION
## Summary
- **Fix CI crash**: Pin `yfinance==1.3.0` (was 0.2.36 which lacks the `EquityQuery` screener API, causing `ImportError` on line 2 of `stock_info_etl.py`)
- **Migrate scoring to polars**: Rewrite `scoring.py` from pandas row-wise `apply()` to polars expression-based column operations. Update `generate_site.py` accordingly. Pandas remains as a transitive yfinance dependency.
- **Fix ebitda bug**: The old code looked for `ebitda_price` (assuming a column name collision that doesn't exist), silently dropping the `ebitda` column from output

## Test plan
- [ ] Merge and re-run the GitHub Actions workflow — should no longer crash on import
- [ ] Verify `_site/data.json` contains expected screening columns including `ebitda`
- [ ] Verify static site deploys to GitHub Pages

https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv)_