### PR TITLE
Fix artifact restore to accept any workflow conclusion

### DIFF
--- a/.github/workflows/screener.yml
+++ b/.github/workflows/screener.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           name: stocks-database
           workflow: screener.yml
+          workflow_conclusion: ''
           search_artifacts: true
           if_no_artifact_found: warn
         continue-on-error: true


### PR DESCRIPTION
## Summary
- The `dawidd6/action-download-artifact` action defaults to `workflow_conclusion: success`, so it only looks for artifacts from successful runs
- Since the DB artifact is uploaded with `if: always()`, it exists even from failed runs — but the download step was never finding it
- Set `workflow_conclusion: ''` to match artifacts from any run conclusion

## Test plan
- [ ] Merge and re-run the workflow
- [ ] Verify the "Restore previous database" step finds and downloads the artifact from a prior run

https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv)_