### PR TITLE
Run financials ETL before prices, reduce sleep

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -35,8 +35,8 @@ def run_etl():
 
     etl_steps = [
         ('Stock Info', StockInfoETL),
-        ('Stock Valuation', StockValuationETL),
         ('Financial Statements', StockFinancialStatementsETL),
+        ('Stock Valuation', StockValuationETL),
     ]
 
     failures = []

--- a/utils/stock_financial_statements_etl.py
+++ b/utils/stock_financial_statements_etl.py
@@ -69,6 +69,6 @@ class StockFinancialStatementsETL(ETLBase):
                 logger.error('Failed to get financials for %s: %s' % (yahoo_ticker, e))
                 failed += 1
                 continue
-            time.sleep(0.5)
+            time.sleep(0.1)
 
         logger.info('Financials ETL complete: %s stocks fetched, %s failed' % (fetched, failed))

--- a/utils/stock_valuation_etl.py
+++ b/utils/stock_valuation_etl.py
@@ -36,5 +36,5 @@ class StockValuationETL(ETLBase):
                 logger.error('Failed to get price for %s: %s' % (yahoo_ticker, e))
                 failed += 1
                 continue
-            time.sleep(0.5)
+            time.sleep(0.1)
         logger.info('Price ETL complete: %s fetched, %s failed' % (fetched, failed))


### PR DESCRIPTION
## Summary
- Reorder ETL steps: Stock Info → Financial Statements → Prices (financials are more important for screening, prices can be scraped from anywhere)
- Reduce inter-request sleep from 0.5s to 0.1s in both valuation and financial statements ETLs — yfinance 1.3.0 handles rate limiting internally, saving ~10 minutes on a full run

## Test plan
- [ ] Merge and run workflow
- [ ] Verify financials ETL runs before prices in the logs
- [ ] Verify no rate limiting issues from yfinance

https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj3babkApwSYEY74jT7GTv)_