### PR TITLE
Add Top Picks view with Quality, Value, and Deep Value buckets

### DIFF
--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -13,12 +13,15 @@ import { Toolbar } from './components/Toolbar';
 import { StockTable } from './components/StockTable';
 import { StockCards } from './components/StockCards';
 import { ColumnPicker } from './components/ColumnPicker';
+import { TopPicks } from './components/TopPicks';
 import { useDebounced, useMediaQuery } from './hooks';
 import { downloadCsv } from './csv';
+import { computeTopPicks, unionPicks } from './topPicks';
 
 const MOBILE_QUERY = '(max-width: 768px)';
 
 const PRESET_SORT: Record<PresetId, SortingState> = {
+  top_picks: [{ id: 'magic_formula_score', desc: true }],
   overview: [{ id: 'magic_formula_score', desc: true }],
   piotroski: [{ id: 'p_score', desc: true }],
   magic: [{ id: 'magic_formula_score', desc: true }],
@@ -27,6 +30,7 @@ const PRESET_SORT: Record<PresetId, SortingState> = {
 };
 
 const PRIMARY_METRIC: Record<PresetId, { key: keyof Stock; label: string; type: 'pct' | 'num' | 'score' }> = {
+  top_picks: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
   overview: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
   piotroski: { key: 'p_score', label: 'Piotroski', type: 'score' },
   magic: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
@@ -112,20 +116,27 @@ export function App() {
     [table, sorting, filteredRows],
   );
 
+  const topPickRows = useMemo(
+    () => (preset === 'top_picks' ? unionPicks(computeTopPicks(filteredRows)) : []),
+    [preset, filteredRows],
+  );
+
+  const displayRows = preset === 'top_picks' ? topPickRows : sortedRows;
+
   const handlePreset = (p: PresetId) => {
     setPreset(p);
     setSorting(PRESET_SORT[p]);
     setColumnVisibility(visibilityForPreset(p));
   };
 
-  const downloadAll = () => downloadCsv(sortedRows);
+  const downloadAll = () => downloadCsv(displayRows);
 
   return (
     <div className="app-root">
       <Toolbar
         generatedAt={payload?.generated_at || ''}
         totalRows={rows.length}
-        visibleRows={sortedRows.length}
+        visibleRows={displayRows.length}
         search={search}
         onSearch={setSearch}
         preset={preset}
@@ -149,7 +160,9 @@ export function App() {
         {!loadError && !payload && (
           <div className="loading">Loading screening results…</div>
         )}
+        {payload && preset === 'top_picks' && <TopPicks rows={filteredRows} />}
         {payload &&
+          preset !== 'top_picks' &&
           (isMobile ? (
             <StockCards rows={sortedRows} primaryMetric={PRIMARY_METRIC[preset]} />
           ) : (
@@ -159,7 +172,7 @@ export function App() {
 
       <footer className="site-footer">
         <span>
-          {presets[preset].label} · {sortedRows.length.toLocaleString()} stocks
+          {presets[preset].label} · {displayRows.length.toLocaleString()} stocks
         </span>
         <a href="https://github.com/lseffer/stock_screener" target="_blank" rel="noreferrer">
           Source on GitHub ↗

--- a/web/app/src/columns.tsx
+++ b/web/app/src/columns.tsx
@@ -201,6 +201,19 @@ export const columns = [
 export const ALL_COLUMN_IDS = columns.map((c) => c.id as string);
 
 export const presets: Record<PresetId, { label: string; visible: string[] }> = {
+  top_picks: {
+    label: 'Top Picks',
+    visible: [
+      'company_name',
+      'sector',
+      'p_score',
+      'magic_formula_score',
+      'roic',
+      'ev_ebitda_ratio',
+      'price',
+      'market_cap',
+    ],
+  },
   overview: {
     label: 'Overview',
     visible: [

--- a/web/app/src/components/TopPicks.tsx
+++ b/web/app/src/components/TopPicks.tsx
@@ -1,0 +1,103 @@
+import type { Stock } from '../types';
+import { computeTopPicks, type PickBucket, type PickMetric } from '../topPicks';
+import { fmtDecimal, fmtPercent } from '../format';
+
+interface TopPicksProps {
+  rows: Stock[];
+}
+
+function formatMetric(stock: Stock, metric: PickMetric): string {
+  const raw = stock[metric.key];
+  const value = typeof raw === 'number' ? raw : null;
+  if (metric.type === 'pct') return fmtPercent(value);
+  return fmtDecimal(value);
+}
+
+function pillTone(score: number | null | undefined): 'good' | 'mid' | 'bad' | null {
+  if (typeof score !== 'number') return null;
+  if (score >= 7) return 'good';
+  if (score >= 5) return 'mid';
+  return 'bad';
+}
+
+function PickRow({ stock, rank, primary, secondary }: {
+  stock: Stock;
+  rank: number;
+  primary: PickMetric;
+  secondary: PickMetric;
+}) {
+  const name = stock.company_name ?? stock.isin;
+  const symbol = stock.symbol ?? stock.isin;
+  const href = `https://www.google.com/search?q=${encodeURIComponent(`${name} ${symbol} stock`)}`;
+
+  const isPiotroskiSecondary = secondary.key === 'p_score';
+  const secondaryValue = stock[secondary.key];
+  const tone = isPiotroskiSecondary ? pillTone(secondaryValue as number | null) : null;
+
+  return (
+    <li className="pick-item">
+      <span className="pick-rank">{rank}</span>
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className="pick-link"
+      >
+        <span className="pick-name">{name}</span>
+        <span className="pick-sub">
+          {symbol}
+          {stock.sector ? <span className="pick-sector"> · {stock.sector}</span> : null}
+        </span>
+      </a>
+      <span className="pick-metrics">
+        <span className="pick-primary">{formatMetric(stock, primary)}</span>
+        <span className="pick-secondary">
+          {secondary.label}:{' '}
+          {tone ? (
+            <span className={`pill pill-${tone}`}>{secondaryValue as number}</span>
+          ) : (
+            formatMetric(stock, secondary)
+          )}
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function Bucket({ bucket }: { bucket: PickBucket }) {
+  return (
+    <section className="pick-bucket" aria-labelledby={`bucket-${bucket.id}`}>
+      <header className="pick-bucket-header">
+        <h2 id={`bucket-${bucket.id}`}>{bucket.title}</h2>
+        <p>{bucket.description}</p>
+        <span className="pick-bucket-metric">Ranked by {bucket.primary.label}</span>
+      </header>
+      {bucket.picks.length === 0 ? (
+        <p className="pick-empty">No stocks meet these criteria in the current filter.</p>
+      ) : (
+        <ol className="pick-list">
+          {bucket.picks.map((stock, i) => (
+            <PickRow
+              key={stock.isin}
+              stock={stock}
+              rank={i + 1}
+              primary={bucket.primary}
+              secondary={bucket.secondary}
+            />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+export function TopPicks({ rows }: TopPicksProps) {
+  const buckets = computeTopPicks(rows);
+  return (
+    <div className="top-picks-grid">
+      {buckets.map((b) => (
+        <Bucket key={b.id} bucket={b} />
+      ))}
+    </div>
+  );
+}

--- a/web/app/src/styles.css
+++ b/web/app/src/styles.css
@@ -543,6 +543,131 @@ body {
   color: var(--text-muted);
 }
 
+/* ---------- Top Picks ---------- */
+
+.top-picks-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.pick-bucket {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 14px 14px 6px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.pick-bucket-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+  margin-bottom: 6px;
+}
+.pick-bucket-header h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.pick-bucket-header p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.pick-bucket-metric {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.pick-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pick-item {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.pick-item:last-child { border-bottom: none; }
+
+.pick-rank {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.pick-link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--text);
+  line-height: 1.2;
+  min-width: 0;
+}
+.pick-link:hover .pick-name { color: var(--primary); }
+
+.pick-name {
+  font-weight: 600;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pick-sub {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pick-sector { opacity: 0.85; }
+
+.pick-metrics {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.pick-primary {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pick-secondary {
+  font-size: 11px;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pick-empty {
+  padding: 24px 0;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 /* ---------- Footer ---------- */
 
 .site-footer {
@@ -577,4 +702,5 @@ body {
     flex-direction: column;
   }
   .card-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .top-picks-grid { grid-template-columns: 1fr; }
 }

--- a/web/app/src/topPicks.ts
+++ b/web/app/src/topPicks.ts
@@ -1,0 +1,144 @@
+import type { Stock } from './types';
+
+export const TOP_PICKS_PER_BUCKET = 5;
+
+export type BucketId = 'quality' | 'value' | 'deep_value';
+
+export type MetricType = 'pct' | 'num' | 'score';
+
+export interface PickMetric {
+  key: keyof Stock;
+  label: string;
+  type: MetricType;
+}
+
+export interface PickBucket {
+  id: BucketId;
+  title: string;
+  description: string;
+  picks: Stock[];
+  primary: PickMetric;
+  secondary: PickMetric;
+}
+
+const QUALITY_MIN_P_SCORE = 7;
+const QUALITY_MIN_ROIC = 0.1;
+const VALUE_MIN_P_SCORE = 5;
+const DEEP_VALUE_MIN_P_SCORE = 5;
+const DEEP_VALUE_MAX_PE = 10;
+
+function num(v: number | null | undefined): number | null {
+  return typeof v === 'number' && !Number.isNaN(v) ? v : null;
+}
+
+function quality(rows: Stock[]): Stock[] {
+  return rows
+    .filter((r) => {
+      const p = num(r.p_score);
+      const roic = num(r.roic);
+      return p !== null && p >= QUALITY_MIN_P_SCORE && roic !== null && roic > QUALITY_MIN_ROIC;
+    })
+    .sort((a, b) => {
+      const ra = num(a.roic) ?? -Infinity;
+      const rb = num(b.roic) ?? -Infinity;
+      if (rb !== ra) return rb - ra;
+      const pa = num(a.p_score) ?? -Infinity;
+      const pb = num(b.p_score) ?? -Infinity;
+      return pb - pa;
+    })
+    .slice(0, TOP_PICKS_PER_BUCKET);
+}
+
+function value(rows: Stock[]): Stock[] {
+  return rows
+    .filter((r) => {
+      const mf = num(r.magic_formula_score);
+      const p = num(r.p_score);
+      const roic = num(r.roic);
+      return (
+        mf !== null &&
+        p !== null &&
+        p >= VALUE_MIN_P_SCORE &&
+        roic !== null &&
+        roic > 0
+      );
+    })
+    .sort((a, b) => {
+      const ma = num(a.magic_formula_score) ?? -Infinity;
+      const mb = num(b.magic_formula_score) ?? -Infinity;
+      return mb - ma;
+    })
+    .slice(0, TOP_PICKS_PER_BUCKET);
+}
+
+function deepValue(rows: Stock[]): Stock[] {
+  return rows
+    .filter((r) => {
+      const ncav = num(r.ncav_ratio);
+      const pe = num(r.trailing_pe);
+      const p = num(r.p_score);
+      const ncavMatch = ncav !== null && ncav > 1;
+      const peMatch =
+        pe !== null &&
+        pe > 0 &&
+        pe <= DEEP_VALUE_MAX_PE &&
+        p !== null &&
+        p >= DEEP_VALUE_MIN_P_SCORE;
+      return ncavMatch || peMatch;
+    })
+    .sort((a, b) => {
+      const na = num(a.ncav_ratio);
+      const nb = num(b.ncav_ratio);
+      const aHasNcav = na !== null && na > 1;
+      const bHasNcav = nb !== null && nb > 1;
+      if (aHasNcav && bHasNcav) return (nb ?? 0) - (na ?? 0);
+      if (aHasNcav) return -1;
+      if (bHasNcav) return 1;
+      const pea = num(a.trailing_pe) ?? Infinity;
+      const peb = num(b.trailing_pe) ?? Infinity;
+      return pea - peb;
+    })
+    .slice(0, TOP_PICKS_PER_BUCKET);
+}
+
+export function computeTopPicks(rows: Stock[]): PickBucket[] {
+  return [
+    {
+      id: 'quality',
+      title: 'Quality',
+      description: 'Strong fundamentals: Piotroski F-Score ≥ 7 with ROIC above 10%.',
+      picks: quality(rows),
+      primary: { key: 'roic', label: 'ROIC', type: 'pct' },
+      secondary: { key: 'p_score', label: 'F-Score', type: 'score' },
+    },
+    {
+      id: 'value',
+      title: 'Value',
+      description: "Greenblatt's Magic Formula — good businesses trading cheaply.",
+      picks: value(rows),
+      primary: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
+      secondary: { key: 'roic', label: 'ROIC', type: 'pct' },
+    },
+    {
+      id: 'deep_value',
+      title: 'Deep Value',
+      description: 'Graham-style net-nets and low-multiple contrarian picks.',
+      picks: deepValue(rows),
+      primary: { key: 'ncav_ratio', label: 'NCAV', type: 'num' },
+      secondary: { key: 'trailing_pe', label: 'P/E', type: 'num' },
+    },
+  ];
+}
+
+export function unionPicks(buckets: PickBucket[]): Stock[] {
+  const seen = new Set<string>();
+  const out: Stock[] = [];
+  for (const b of buckets) {
+    for (const s of b.picks) {
+      if (seen.has(s.isin)) continue;
+      seen.add(s.isin);
+      out.push(s);
+    }
+  }
+  return out;
+}

--- a/web/app/src/types.ts
+++ b/web/app/src/types.ts
@@ -31,4 +31,4 @@ export interface DataPayload {
   rows: Stock[];
 }
 
-export type PresetId = 'overview' | 'piotroski' | 'magic' | 'value' | 'all';
+export type PresetId = 'top_picks' | 'overview' | 'piotroski' | 'magic' | 'value' | 'all';


### PR DESCRIPTION
Surfaces three curated 5-stock shortlists from the existing data so
new visitors get an opinionated starting point instead of a generic
table. Picks are computed deterministically from fields already in
data.json (Piotroski F-Score, ROIC, Magic Formula score, NCAV ratio,
trailing P/E) — no LLM, no backend changes. Bucket thresholds live
in a single constants block in topPicks.ts so they're easy to tune.