### PR TITLE
Make ETL logs ticker-aware and improve logging setup

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -17,8 +17,10 @@ from pathlib import Path
 
 import polars as pl
 
-from utils.config import DB_PATH, OUTPUT_DIR, engine, get_last_year, logger
+from utils.config import DB_PATH, OUTPUT_DIR, engine, get_last_year, get_logger
 from utils.models import Base
+
+logger = get_logger('pipeline')
 
 
 WEB_APP_DIR = Path(__file__).parent / 'web' / 'app'
@@ -27,7 +29,7 @@ WEB_APP_DIST = WEB_APP_DIR / 'dist'
 
 def init_database():
     """Create all tables in the SQLite database."""
-    logger.info('Initializing database at %s' % DB_PATH)
+    logger.info('Initializing database at %s', DB_PATH)
     Base.metadata.create_all(engine)
 
 
@@ -46,15 +48,15 @@ def run_etl():
 
     failures = []
     for name, etl_class in etl_steps:
-        logger.info('=== Running %s ETL ===' % name)
+        logger.info('=== Running %s ETL ===', name)
         try:
             etl_class.job()
-        except Exception as e:
-            logger.error('ETL step "%s" failed: %s' % (name, e))
+        except Exception:
+            logger.exception('ETL step "%s" failed', name)
             failures.append(name)
 
     if failures:
-        logger.warning('ETL completed with failures in: %s' % ', '.join(failures))
+        logger.warning('ETL completed with failures in: %s', ', '.join(failures))
 
 
 def compute_scores():
@@ -76,7 +78,7 @@ def compute_scores():
     filtered = results.filter(pl.col('report_year') == last_year).drop('report_year')
 
     if filtered.is_empty():
-        logger.warning('No results for fiscal year %s, returning all results' % last_year)
+        logger.warning('No results for fiscal year %s, returning all results', last_year)
         filtered = results.drop('report_year')
 
     # Convert to JSON-serializable format
@@ -92,7 +94,7 @@ def compute_scores():
         for key in record:
             record[key] = convert_value(record[key])
 
-    logger.info('Generated %s screening results for output' % len(records))
+    logger.info('Generated %s screening results for output', len(records))
     return records
 
 
@@ -105,7 +107,7 @@ def build_web_app():
     """
     index_html = WEB_APP_DIST / 'index.html'
     if index_html.exists():
-        logger.info('Using prebuilt frontend at %s' % WEB_APP_DIST)
+        logger.info('Using prebuilt frontend at %s', WEB_APP_DIST)
         return
 
     if not WEB_APP_DIR.exists():
@@ -120,7 +122,7 @@ def build_web_app():
             'Run `npm ci && npm run build` inside %s and retry.' % WEB_APP_DIR
         )
 
-    logger.info('Building frontend in %s' % WEB_APP_DIR)
+    logger.info('Building frontend in %s', WEB_APP_DIR)
     if not (WEB_APP_DIR / 'node_modules').exists():
         subprocess.run([npm, 'ci'], cwd=WEB_APP_DIR, check=True)
     subprocess.run([npm, 'run', 'build'], cwd=WEB_APP_DIR, check=True)
@@ -154,12 +156,12 @@ def generate_site(data):
     data_path = output_dir / 'data.json'
     with open(data_path, 'w') as f:
         json.dump(payload, f)
-    logger.info('Wrote %s records to %s' % (len(data), data_path))
+    logger.info('Wrote %s records to %s', len(data), data_path)
 
     # Copy SQLite database to output for download
     if os.path.exists(DB_PATH):
         shutil.copy2(DB_PATH, output_dir / 'stocks.db')
-        logger.info('Copied database to %s' % (output_dir / 'stocks.db'))
+        logger.info('Copied database to %s', output_dir / 'stocks.db')
 
 
 def main():
@@ -176,7 +178,7 @@ def main():
     if not args.etl_only:
         data = compute_scores()
         generate_site(data)
-        logger.info('=== Site generation complete: %s ===' % OUTPUT_DIR)
+        logger.info('=== Site generation complete: %s ===', OUTPUT_DIR)
 
 
 if __name__ == '__main__':

--- a/scoring.py
+++ b/scoring.py
@@ -4,8 +4,10 @@ replacing the PostgreSQL materialized views.
 """
 import sqlite3
 import polars as pl
-from utils.config import DB_PATH, logger
+from utils.config import DB_PATH, get_logger
 from utils.fx import EUR_RATES
+
+logger = get_logger('scoring')
 
 
 def _get_conn():
@@ -243,6 +245,9 @@ def compute_screen_results() -> pl.DataFrame:
         logger.warning('No financial data available')
         return pl.DataFrame()
 
+    n_companies = fin_data['isin'].n_unique()
+    logger.info('Loaded %s rows across %s companies', len(fin_data), n_companies)
+
     logger.info('Computing Piotroski scores...')
     piotroski = compute_piotroski_scores(fin_data)
 
@@ -290,7 +295,10 @@ def compute_screen_results() -> pl.DataFrame:
     existing_output_cols = [c for c in output_cols if c in results.columns]
     results = results.select(existing_output_cols)
 
-    logger.info('Computed screen results for %s stock-periods' % len(results))
+    logger.info(
+        'Computed screen results: %s rows across %s companies',
+        len(results), results['isin'].n_unique(),
+    )
     return results
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,41 @@
+import logging
+import unittest
+
+from utils.config import bind_ticker, get_logger, setup_logging
+
+
+class TestLoggingSetup(unittest.TestCase):
+    def test_setup_is_idempotent(self):
+        a = setup_logging()
+        b = setup_logging()
+        self.assertIs(a, b)
+        self.assertEqual(len(a.handlers), 1, 'duplicate handlers added on repeated calls')
+
+    def test_get_logger_creates_child_under_package(self):
+        log = get_logger('valuation')
+        self.assertEqual(log.name, 'stock_screener.valuation')
+        self.assertIs(log.parent, logging.getLogger('stock_screener'))
+
+    def test_bind_ticker_prefixes_messages(self):
+        log = get_logger('valuation')
+        adapter = bind_ticker(log, 'ERIC-B.ST')
+
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        capture = _Capture()
+        log.addHandler(capture)
+        try:
+            adapter.info('fetched price %s', 152.30)
+        finally:
+            log.removeHandler(capture)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].getMessage(), '[ERIC-B.ST] fetched price 152.3')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -24,17 +24,52 @@ engine = create_sqlite_engine()
 Session = sessionmaker(bind=engine)
 
 
-def setup_logging(level: int = logging.INFO) -> logging.Logger:
-    log = logging.getLogger('stock_screener')
-    log.setLevel(level)
-    formatter = logging.Formatter('%(asctime)s - %(module)s - %(funcName)s - %(levelname)s - %(message)s')
+_PACKAGE_LOGGER = 'stock_screener'
+_LOG_FORMAT = '%(asctime)s [%(levelname)-5s] %(name)s: %(message)s'
+_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(formatter)
-    stdout_handler.setLevel(level)
-    log.addHandler(stdout_handler)
 
+def _resolve_level(level):
+    if level is not None:
+        return level
+    raw = os.getenv('STOCK_SCREENER_LOG_LEVEL', 'INFO').upper()
+    return getattr(logging, raw, logging.INFO)
+
+
+def setup_logging(level=None) -> logging.Logger:
+    """Configure the package logger. Idempotent: safe to call multiple times."""
+    log = logging.getLogger(_PACKAGE_LOGGER)
+    log.setLevel(_resolve_level(level))
+    if not log.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT))
+        log.addHandler(handler)
+        log.propagate = False
     return log
 
 
-logger = setup_logging(logging.INFO)
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a child logger under the ``stock_screener`` namespace.
+
+    Pass a short, descriptive name like ``"valuation"`` rather than ``__name__``
+    so the log output stays grep-able.
+    """
+    setup_logging()
+    if not name or name == _PACKAGE_LOGGER:
+        return logging.getLogger(_PACKAGE_LOGGER)
+    return logging.getLogger(f'{_PACKAGE_LOGGER}.{name}')
+
+
+class _TickerAdapter(logging.LoggerAdapter):
+    """Logger adapter that prefixes every message with the bound ticker."""
+
+    def process(self, msg, kwargs):
+        return f"[{self.extra['ticker']}] {msg}", kwargs
+
+
+def bind_ticker(log: logging.Logger, ticker: str) -> logging.LoggerAdapter:
+    """Wrap ``log`` so every emitted message is prefixed with ``[ticker]``."""
+    return _TickerAdapter(log, {'ticker': ticker})
+
+
+logger = setup_logging()

--- a/utils/etl_base.py
+++ b/utils/etl_base.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
-from utils.config import Session, logger
-from traceback import format_exc
 from typing import List
+
+from utils.config import Session, get_logger
 from utils.models import Base
+
+logger = get_logger('etl')
 
 
 class ETLBase(ABC):
@@ -17,7 +19,7 @@ class ETLBase(ABC):
             return True
         except Exception:
             session.rollback()
-            logger.error('Failed to persist record: %s' % format_exc())
+            logger.exception('Failed to persist %s', type(record).__name__)
             return False
         finally:
             session.close()
@@ -26,24 +28,23 @@ class ETLBase(ABC):
     def load_records(data: List[Base]) -> int:
         """Persist a batch of records, committing in chunks. Returns count of successful records."""
         if not data:
-            logger.info('No data to load')
             return 0
         session = Session()
         loaded = 0
-        for idx, record in enumerate(data):
+        for record in data:
             try:
                 session.merge(record)
                 loaded += 1
             except Exception:
-                logger.warning('Skipping bad record: %s' % format_exc())
                 session.rollback()
+                logger.exception('Skipping bad %s record', type(record).__name__)
                 continue
             if loaded > 0 and loaded % 100 == 0:
                 session.commit()
-                logger.info('Committed %s records' % loaded)
+                logger.debug('Committed %s records (batch)', loaded)
         session.commit()
         session.close()
-        logger.info('Loaded %s/%s records' % (loaded, len(data)))
+        logger.debug('Loaded %s/%s records', loaded, len(data))
         return loaded
 
     @staticmethod

--- a/utils/stock_financial_statements_etl.py
+++ b/utils/stock_financial_statements_etl.py
@@ -1,11 +1,15 @@
-import yfinance as yf
-from utils.queries import fetch_all_tickers_from_database, fetch_tickers_needing_financials
-from utils import union_of_list_elements
-from utils.models import Base, BalanceSheetStatement, CashFlowStatement, IncomeStatement
-from utils.config import logger
-from utils.etl_base import ETLBase
-from typing import List
 import time
+from typing import List
+
+import yfinance as yf
+
+from utils import union_of_list_elements
+from utils.config import bind_ticker, get_logger
+from utils.etl_base import ETLBase
+from utils.models import Base, BalanceSheetStatement, CashFlowStatement, IncomeStatement
+from utils.queries import fetch_all_tickers_from_database, fetch_tickers_needing_financials
+
+logger = get_logger('financials')
 
 
 class StockFinancialStatementsETL(ETLBase):
@@ -20,55 +24,68 @@ class StockFinancialStatementsETL(ETLBase):
         tickers_to_fetch = union_of_list_elements(needs_income, needs_balance, needs_cashflow)
 
         skipped = len(all_tickers) - len(tickers_to_fetch)
+        total = len(tickers_to_fetch)
         logger.info(
-            'Skipping %s stocks with current financials, fetching %s'
-            % (skipped, len(tickers_to_fetch))
+            'Skipping %s stocks with current financials, fetching %s',
+            skipped, total,
         )
 
         fetched = 0
         failed = 0
-        for isin, yahoo_ticker in tickers_to_fetch:
+        for idx, (isin, yahoo_ticker) in enumerate(tickers_to_fetch, start=1):
             if not yahoo_ticker:
                 continue
+            log = bind_ticker(logger, yahoo_ticker)
+            progress = f'[{idx}/{total}]'
             try:
                 ticker = yf.Ticker(yahoo_ticker)
                 records: List[Base] = []
+                counts = {'income': 0, 'balance': 0, 'cashflow': 0}
 
                 income_df = ticker.income_stmt
                 if income_df is not None and not income_df.empty:
                     for col_date in income_df.columns:
                         try:
                             records.append(IncomeStatement.from_yfinance_column(income_df, col_date, isin))
+                            counts['income'] += 1
                         except Exception as e:
-                            logger.warning('Failed income stmt %s/%s: %s' % (yahoo_ticker, col_date, e))
+                            log.warning('income stmt %s skipped: %s', col_date, e)
 
                 bs_df = ticker.balance_sheet
                 if bs_df is not None and not bs_df.empty:
                     for col_date in bs_df.columns:
                         try:
                             records.append(BalanceSheetStatement.from_yfinance_column(bs_df, col_date, isin))
+                            counts['balance'] += 1
                         except Exception as e:
-                            logger.warning('Failed balance sheet %s/%s: %s' % (yahoo_ticker, col_date, e))
+                            log.warning('balance sheet %s skipped: %s', col_date, e)
 
                 cf_df = ticker.cashflow
                 if cf_df is not None and not cf_df.empty:
                     for col_date in cf_df.columns:
                         try:
                             records.append(CashFlowStatement.from_yfinance_column(cf_df, col_date, isin))
+                            counts['cashflow'] += 1
                         except Exception as e:
-                            logger.warning('Failed cashflow %s/%s: %s' % (yahoo_ticker, col_date, e))
+                            log.warning('cashflow %s skipped: %s', col_date, e)
 
-                # Commit all statements for this stock in one batch
                 loaded = ETLBase.load_records(records)
                 if loaded > 0:
                     fetched += 1
-                    logger.debug('Got %s statements for %s' % (loaded, yahoo_ticker))
+                    log.info(
+                        '%s loaded %s statements (income=%s balance=%s cashflow=%s)',
+                        progress, loaded, counts['income'], counts['balance'], counts['cashflow'],
+                    )
                 else:
                     failed += 1
+                    log.warning('%s no statements available', progress)
             except Exception as e:
-                logger.error('Failed to get financials for %s: %s' % (yahoo_ticker, e))
+                log.exception('%s fetch failed: %s', progress, e)
                 failed += 1
                 continue
             time.sleep(0.1)
 
-        logger.info('Financials ETL complete: %s stocks fetched, %s failed' % (fetched, failed))
+        logger.info(
+            'Financials ETL complete: %s fetched, %s failed (of %s)',
+            fetched, failed, total,
+        )

--- a/utils/stock_info_etl.py
+++ b/utils/stock_info_etl.py
@@ -2,8 +2,10 @@ import yfinance as yf
 from yfinance import EquityQuery
 from utils.models import Stock
 from utils.etl_base import ETLBase
-from utils.config import logger
+from utils.config import get_logger
 from typing import Dict, List
+
+logger = get_logger('stock_info')
 
 # Yahoo Finance exchange codes for Nordic markets
 NORDIC_EXCHANGES = {
@@ -42,21 +44,25 @@ class StockInfoETL(ETLBase):
     def job() -> None:
         total = 0
         for exchange_code, exchange_name in NORDIC_EXCHANGES.items():
-            logger.info('Fetching stock list for %s (%s)' % (exchange_name, exchange_code))
+            logger.info('Fetching stock list for %s (%s)', exchange_name, exchange_code)
             try:
                 quotes = fetch_exchange_stocks(exchange_code)
-                logger.info('Found %s stocks on %s' % (len(quotes), exchange_name))
+                logger.info('Found %s stocks on %s', len(quotes), exchange_name)
             except Exception as e:
-                logger.error('Failed to fetch %s stock list: %s' % (exchange_name, e))
+                logger.exception('Failed to fetch %s stock list: %s', exchange_name, e)
                 continue
 
+            loaded = 0
             for quote in quotes:
+                symbol = quote.get('symbol', '?')
                 try:
                     record = Stock.from_yfinance_screener(quote)
                     if record.yahoo_ticker:
                         ETLBase.load_record(record)
                         total += 1
+                        loaded += 1
                 except Exception as e:
-                    logger.warning('Failed to process quote %s: %s' % (quote.get('symbol', '?'), e))
+                    logger.warning('[%s] failed to process quote: %s', symbol, e)
+            logger.info('Loaded %s stocks from %s', loaded, exchange_name)
 
-        logger.info('Stock info ETL complete: %s stocks loaded' % total)
+        logger.info('Stock info ETL complete: %s stocks loaded', total)

--- a/utils/stock_valuation_etl.py
+++ b/utils/stock_valuation_etl.py
@@ -1,9 +1,13 @@
-import yfinance as yf
-from utils.queries import fetch_all_tickers_from_database, fetch_tickers_needing_price_update
-from utils.models import Price
-from utils.config import logger
-from utils.etl_base import ETLBase
 import time
+
+import yfinance as yf
+
+from utils.config import bind_ticker, get_logger
+from utils.etl_base import ETLBase
+from utils.models import Price
+from utils.queries import fetch_all_tickers_from_database, fetch_tickers_needing_price_update
+
+logger = get_logger('valuation')
 
 
 class StockValuationETL(ETLBase):
@@ -13,28 +17,48 @@ class StockValuationETL(ETLBase):
         all_tickers = fetch_all_tickers_from_database()
         stale_tickers = fetch_tickers_needing_price_update(max_age_days=5)
         skipped = len(all_tickers) - len(stale_tickers)
-        logger.info('Skipping %s stocks with recent prices, fetching %s' % (skipped, len(stale_tickers)))
+        total = len(stale_tickers)
+        logger.info('Skipping %s stocks with recent prices, fetching %s', skipped, total)
 
         fetched = 0
         failed = 0
-        for isin, yahoo_ticker in stale_tickers:
+        for idx, (isin, yahoo_ticker) in enumerate(stale_tickers, start=1):
             if not yahoo_ticker:
                 continue
+            log = bind_ticker(logger, yahoo_ticker)
+            progress = f'[{idx}/{total}]'
             try:
-                ticker = yf.Ticker(yahoo_ticker)
-                info = ticker.info
-                if not info or info.get('regularMarketPrice') is None and info.get('currentPrice') is None:
-                    logger.warning('No data for %s' % yahoo_ticker)
+                info = yf.Ticker(yahoo_ticker).info
+                price = (info or {}).get('regularMarketPrice') or (info or {}).get('currentPrice')
+                if not info or price is None:
+                    log.warning('%s no price data', progress)
                     failed += 1
                     continue
                 record = Price.from_yfinance(info, isin)
                 if ETLBase.load_record(record):
                     fetched += 1
+                    log.info(
+                        '%s fetched price %.2f %s (mkt cap %s)',
+                        progress, price,
+                        info.get('financialCurrency') or info.get('currency') or '?',
+                        _compact(info.get('marketCap')),
+                    )
                 else:
                     failed += 1
+                    log.warning('%s failed to persist price record', progress)
             except Exception as e:
-                logger.error('Failed to get price for %s: %s' % (yahoo_ticker, e))
+                log.exception('%s fetch failed: %s', progress, e)
                 failed += 1
                 continue
             time.sleep(0.1)
-        logger.info('Price ETL complete: %s fetched, %s failed' % (fetched, failed))
+        logger.info('Price ETL complete: %s fetched, %s failed (of %s)', fetched, failed, total)
+
+
+def _compact(value):
+    if value is None:
+        return '?'
+    abs_v = abs(value)
+    for unit, threshold in (('T', 1e12), ('B', 1e9), ('M', 1e6), ('K', 1e3)):
+        if abs_v >= threshold:
+            return f'{value / threshold:.1f}{unit}'
+    return f'{value:.0f}'


### PR DESCRIPTION
- Per-module child loggers under stock_screener.* via get_logger(),
  with a clearer "[LEVEL] name: message" format and STOCK_SCREENER_LOG_LEVEL
  env var support. setup_logging() is now idempotent.
- bind_ticker(logger, ticker) LoggerAdapter prefixes every message with
  the bound ticker, so any log emitted inside a yfinance fetch loop
  carries [ERIC-B.ST]-style context.
- Valuation and financial-statements ETLs now log per-ticker progress at
  INFO level: "[12/487] fetched price SEK 152.30 (mkt cap 487B)" /
  "[37/200] loaded 12 statements (income=4 balance=4 cashflow=4)".
  Failures log a traceback via logger.exception with the same progress
  prefix instead of an opaque "Failed to get X" line.
- Switch all callers to lazy-formatting and demote per-batch counts in
  load_records to DEBUG so they no longer drown out the per-ticker INFO
  lines.