### PR TITLE
Add momentum screening alongside the existing value strategies

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -39,11 +39,13 @@ def run_etl():
     from utils.stock_info_etl import StockInfoETL
     from utils.stock_valuation_etl import StockValuationETL
     from utils.stock_financial_statements_etl import StockFinancialStatementsETL
+    from utils.stock_price_history_etl import StockPriceHistoryETL
 
     etl_steps = [
         ('Stock Info', StockInfoETL),
         ('Financial Statements', StockFinancialStatementsETL),
         ('Stock Valuation', StockValuationETL),
+        ('Price History', StockPriceHistoryETL),
     ]
 
     failures = []

--- a/scoring.py
+++ b/scoring.py
@@ -52,6 +52,69 @@ def load_financial_data() -> pl.DataFrame:
     return df
 
 
+def load_price_history() -> pl.DataFrame:
+    """Load monthly close price history into a polars DataFrame."""
+    conn = _get_conn()
+    df = _read_table('SELECT isin, market_date, close_price FROM price_history', conn, 'price_history')
+    conn.close()
+    if df.is_empty():
+        return df
+    return df.sort(['isin', 'market_date'])
+
+
+def compute_momentum_scores(df: pl.DataFrame) -> pl.DataFrame:
+    """Compute classic momentum signals from monthly close prices.
+
+    Returns one row per isin with the latest market_date and:
+      - return_12_1: 12-month return excluding the most recent month
+                     (close[t-1] / close[t-13] - 1) — the Jegadeesh-Titman factor
+      - return_6m:   close[t] / close[t-6] - 1
+      - return_3m:   close[t] / close[t-3] - 1
+      - momentum_score: equal-weighted mean of the three returns
+    """
+    if df.is_empty():
+        return pl.DataFrame(schema={
+            'isin': pl.String,
+            'market_date': pl.Date,
+            'return_12_1': pl.Float64,
+            'return_6m': pl.Float64,
+            'return_3m': pl.Float64,
+            'momentum_score': pl.Float64,
+        })
+
+    df = df.sort(['isin', 'market_date'])
+
+    df = df.with_columns([
+        pl.col('close_price').shift(1).over('isin').alias('close_t_minus_1'),
+        pl.col('close_price').shift(3).over('isin').alias('close_t_minus_3'),
+        pl.col('close_price').shift(6).over('isin').alias('close_t_minus_6'),
+        pl.col('close_price').shift(13).over('isin').alias('close_t_minus_13'),
+    ])
+
+    df = df.with_columns([
+        _safe_div(pl.col('close_t_minus_1'), pl.col('close_t_minus_13')).alias('_ratio_12_1'),
+        _safe_div(pl.col('close_price'), pl.col('close_t_minus_6')).alias('_ratio_6m'),
+        _safe_div(pl.col('close_price'), pl.col('close_t_minus_3')).alias('_ratio_3m'),
+    ])
+
+    df = df.with_columns([
+        (pl.col('_ratio_12_1') - 1.0).alias('return_12_1'),
+        (pl.col('_ratio_6m') - 1.0).alias('return_6m'),
+        (pl.col('_ratio_3m') - 1.0).alias('return_3m'),
+    ])
+
+    df = df.with_columns(
+        pl.mean_horizontal(['return_12_1', 'return_6m', 'return_3m']).alias('momentum_score')
+    )
+
+    latest = df.group_by('isin').agg(pl.col('market_date').max().alias('market_date'))
+    latest_rows = df.join(latest, on=['isin', 'market_date'], how='inner')
+
+    return latest_rows.select([
+        'isin', 'market_date', 'return_12_1', 'return_6m', 'return_3m', 'momentum_score',
+    ])
+
+
 def compute_piotroski_scores(df: pl.DataFrame) -> pl.DataFrame:
     """Compute Piotroski F-Score (9 financial health metrics)."""
     df = df.with_columns([
@@ -256,6 +319,13 @@ def compute_screen_results() -> pl.DataFrame:
 
     scores = piotroski.join(magic, on=['isin', 'report_date'], how='full', coalesce=True)
 
+    logger.info('Computing Momentum scores...')
+    price_history = load_price_history()
+    momentum = compute_momentum_scores(price_history)
+    if not momentum.is_empty():
+        momentum = momentum.rename({'market_date': 'momentum_date'})
+        scores = scores.join(momentum, on='isin', how='left')
+
     conn = _get_conn()
     stocks = _read_table('SELECT isin, name, symbol, currency, sector, yahoo_ticker FROM stocks', conn, 'stocks')
     conn.close()
@@ -278,6 +348,7 @@ def compute_screen_results() -> pl.DataFrame:
     results = _add_cap_tier(results)
     results = _add_shareholder_yield_total(results)
     results = _add_percentile_ranks(results)
+    results = _add_value_momentum_score(results)
 
     output_cols = [
         'isin', 'company_name', 'symbol', 'currency', 'sector', 'yahoo_ticker',
@@ -291,6 +362,8 @@ def compute_screen_results() -> pl.DataFrame:
         'trailing_pe', 'forward_pe', 'ev_ebitda_ratio', 'magic_formula_score',
         'magic_formula_score_percentile', 'roic_percentile',
         'shareholder_yield_percentile',
+        'momentum_date', 'return_12_1', 'return_6m', 'return_3m',
+        'momentum_score', 'momentum_score_percentile', 'value_momentum_score',
     ]
     existing_output_cols = [c for c in output_cols if c in results.columns]
     results = results.select(existing_output_cols)
@@ -368,7 +441,7 @@ def _percentile_expr(col: str) -> pl.Expr:
 
 def _add_percentile_ranks(df: pl.DataFrame) -> pl.DataFrame:
     exprs = []
-    for col in ('magic_formula_score', 'roic', 'shareholder_yield_total'):
+    for col in ('magic_formula_score', 'roic', 'shareholder_yield_total', 'momentum_score'):
         if col in df.columns:
             exprs.append(_percentile_expr(col))
     # shareholder_yield_total_percentile -> shareholder_yield_percentile for brevity
@@ -376,3 +449,27 @@ def _add_percentile_ranks(df: pl.DataFrame) -> pl.DataFrame:
     if 'shareholder_yield_total_percentile' in df.columns:
         df = df.rename({'shareholder_yield_total_percentile': 'shareholder_yield_percentile'})
     return df
+
+
+def _add_value_momentum_score(df: pl.DataFrame) -> pl.DataFrame:
+    """Composite of value (Magic Formula) and momentum percentile ranks.
+
+    Average of magic_formula_score_percentile and momentum_score_percentile.
+    Null when either input is missing — both factors must be present to qualify
+    as a value+momentum pick."""
+    if (
+        'magic_formula_score_percentile' not in df.columns
+        or 'momentum_score_percentile' not in df.columns
+    ):
+        return df
+    return df.with_columns(
+        pl.when(
+            pl.col('magic_formula_score_percentile').is_null()
+            | pl.col('momentum_score_percentile').is_null()
+        )
+        .then(None)
+        .otherwise(
+            (pl.col('magic_formula_score_percentile') + pl.col('momentum_score_percentile')) / 2.0
+        )
+        .alias('value_momentum_score')
+    )

--- a/tests/test_momentum_scoring.py
+++ b/tests/test_momentum_scoring.py
@@ -1,0 +1,111 @@
+import unittest
+from datetime import date
+
+import polars as pl
+
+from scoring import compute_momentum_scores, _add_value_momentum_score
+
+
+def _monthly_series(start_year: int, start_month: int, n: int):
+    out = []
+    y, m = start_year, start_month
+    for _ in range(n):
+        out.append(date(y, m, 1))
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return out
+
+
+class TestComputeMomentumScores(unittest.TestCase):
+    def test_returns_expected_values_for_full_history(self):
+        # 14 monthly bars: closes 100, 101, 102, ..., 113
+        dates = _monthly_series(2025, 1, 14)
+        closes = [100.0 + i for i in range(14)]
+        df = pl.DataFrame({
+            'isin': ['ABC.ST'] * 14,
+            'market_date': dates,
+            'close_price': closes,
+        })
+
+        out = compute_momentum_scores(df)
+
+        self.assertEqual(out.height, 1)
+        row = out.row(0, named=True)
+        self.assertEqual(row['isin'], 'ABC.ST')
+        self.assertEqual(row['market_date'], dates[-1])
+        # close[t]=113, close[t-1]=112, close[t-3]=110, close[t-6]=107, close[t-13]=100
+        self.assertAlmostEqual(row['return_12_1'], 112.0 / 100.0 - 1.0)
+        self.assertAlmostEqual(row['return_6m'], 113.0 / 107.0 - 1.0)
+        self.assertAlmostEqual(row['return_3m'], 113.0 / 110.0 - 1.0)
+        expected_score = (row['return_12_1'] + row['return_6m'] + row['return_3m']) / 3.0
+        self.assertAlmostEqual(row['momentum_score'], expected_score)
+
+    def test_short_history_yields_null_long_term_returns(self):
+        # Only 5 monthly bars — too short for 12-1 and 6-month returns
+        dates = _monthly_series(2025, 1, 5)
+        closes = [100.0, 102.0, 104.0, 106.0, 110.0]
+        df = pl.DataFrame({
+            'isin': ['SHORT.ST'] * 5,
+            'market_date': dates,
+            'close_price': closes,
+        })
+
+        out = compute_momentum_scores(df)
+
+        self.assertEqual(out.height, 1)
+        row = out.row(0, named=True)
+        self.assertIsNone(row['return_12_1'])
+        self.assertIsNone(row['return_6m'])
+        # 3-month return is computable: close[t]=110, close[t-3]=102
+        self.assertAlmostEqual(row['return_3m'], 110.0 / 102.0 - 1.0)
+        # momentum_score is the mean of available returns (mean_horizontal ignores nulls)
+        self.assertAlmostEqual(row['momentum_score'], row['return_3m'])
+
+    def test_multiple_tickers_returns_one_row_each(self):
+        dates = _monthly_series(2025, 1, 14)
+        closes_a = [100.0 + i for i in range(14)]
+        closes_b = [200.0 - i for i in range(14)]  # falling prices
+        df = pl.DataFrame({
+            'isin': ['A.ST'] * 14 + ['B.ST'] * 14,
+            'market_date': dates + dates,
+            'close_price': closes_a + closes_b,
+        })
+
+        out = compute_momentum_scores(df).sort('isin')
+
+        self.assertEqual(out.height, 2)
+        self.assertEqual(out['isin'].to_list(), ['A.ST', 'B.ST'])
+        # A should have positive momentum, B negative
+        self.assertGreater(out.row(0, named=True)['momentum_score'], 0)
+        self.assertLess(out.row(1, named=True)['momentum_score'], 0)
+
+    def test_empty_input_returns_empty_dataframe_with_schema(self):
+        empty = pl.DataFrame(schema={
+            'isin': pl.String,
+            'market_date': pl.Date,
+            'close_price': pl.Float64,
+        })
+        out = compute_momentum_scores(empty)
+        self.assertEqual(out.height, 0)
+        for col in ('isin', 'market_date', 'return_12_1', 'return_6m', 'return_3m', 'momentum_score'):
+            self.assertIn(col, out.columns)
+
+
+class TestValueMomentumScore(unittest.TestCase):
+    def test_averages_percentiles_when_both_present(self):
+        df = pl.DataFrame({
+            'magic_formula_score_percentile': [100.0, 50.0, None, 25.0],
+            'momentum_score_percentile': [50.0, None, 80.0, 75.0],
+        })
+        out = _add_value_momentum_score(df)
+        vm = out['value_momentum_score'].to_list()
+        self.assertAlmostEqual(vm[0], 75.0)
+        self.assertIsNone(vm[1])
+        self.assertIsNone(vm[2])
+        self.assertAlmostEqual(vm[3], 50.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/models/__init__.py
+++ b/utils/models/__init__.py
@@ -1,6 +1,7 @@
 from utils.models.base import Base  # NOQA
 from utils.models.stocks import Stock  # NOQA
 from utils.models.prices import Price  # NOQA
+from utils.models.price_history import PriceHistory  # NOQA
 from utils.models.balance_sheet_statements import BalanceSheetStatement  # NOQA
 from utils.models.income_statements import IncomeStatement  # NOQA
 from utils.models.cash_flow_statements import CashFlowStatement  # NOQA

--- a/utils/models/price_history.py
+++ b/utils/models/price_history.py
@@ -1,0 +1,12 @@
+from utils.models.base import Base
+from sqlalchemy import Column, String, DateTime, Float, Date
+from datetime import datetime
+
+
+class PriceHistory(Base):
+    __tablename__ = 'price_history'
+    isin = Column(String, primary_key=True)
+    market_date = Column(Date, primary_key=True)
+    close_price = Column(Float)
+    dw_created = Column(DateTime, default=datetime.utcnow)
+    dw_modified = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/utils/queries.py
+++ b/utils/queries.py
@@ -9,6 +9,7 @@ from utils.models import (
     CashFlowStatement,
     IncomeStatement,
     Price,
+    PriceHistory,
     Stock,
 )
 
@@ -27,6 +28,27 @@ def fetch_tickers_needing_price_update(max_age_days: int = 5) -> List[Tuple]:
     recently_updated = (
         session.query(Price.isin)
         .filter(Price.market_date >= cutoff)
+        .subquery()
+    )
+    res: List[Tuple] = (
+        session.query(Stock.isin, Stock.yahoo_ticker)
+        .filter(~Stock.isin.in_(session.query(recently_updated.c.isin)))
+        .group_by(Stock.isin, Stock.yahoo_ticker)
+        .all()
+    )
+    session.close()
+    return res
+
+
+def fetch_tickers_needing_price_history(max_age_days: int = 25) -> List[Tuple]:
+    """Return tickers whose latest price_history row is older than max_age_days,
+    or which have no price_history rows at all. Default 25 days is just under
+    a month, so the weekly job picks up the new monthly bar exactly once per month."""
+    session = Session()
+    cutoff = date.today() - timedelta(days=max_age_days)
+    recently_updated = (
+        session.query(PriceHistory.isin)
+        .filter(PriceHistory.market_date >= cutoff)
         .subquery()
     )
     res: List[Tuple] = (

--- a/utils/stock_price_history_etl.py
+++ b/utils/stock_price_history_etl.py
@@ -1,0 +1,78 @@
+import time
+from typing import List
+
+import yfinance as yf
+
+from utils.config import bind_ticker, get_logger
+from utils.etl_base import ETLBase
+from utils.models import Base, PriceHistory
+from utils.queries import fetch_all_tickers_from_database, fetch_tickers_needing_price_history
+
+logger = get_logger('price_history')
+
+
+class StockPriceHistoryETL(ETLBase):
+    """Fetches ~14 months of monthly close prices via yfinance.
+
+    14 months is enough to compute 12-1 momentum (12-month return excluding
+    the most recent month) with one bar of buffer. We re-fetch the whole window
+    each run; the composite PK + SQLAlchemy session.merge in ETLBase handles
+    idempotent upserts."""
+
+    @staticmethod
+    def job() -> None:
+        all_tickers = fetch_all_tickers_from_database()
+        stale_tickers = fetch_tickers_needing_price_history(max_age_days=25)
+        skipped = len(all_tickers) - len(stale_tickers)
+        total = len(stale_tickers)
+        logger.info(
+            'Skipping %s stocks with recent price history, fetching %s',
+            skipped, total,
+        )
+
+        fetched = 0
+        failed = 0
+        for idx, (isin, yahoo_ticker) in enumerate(stale_tickers, start=1):
+            if not yahoo_ticker:
+                continue
+            log = bind_ticker(logger, yahoo_ticker)
+            progress = f'[{idx}/{total}]'
+            try:
+                hist = yf.Ticker(yahoo_ticker).history(
+                    period='14mo', interval='1mo', auto_adjust=True,
+                )
+                if hist is None or hist.empty:
+                    log.warning('%s no price history', progress)
+                    failed += 1
+                    continue
+                records: List[Base] = []
+                for ts, row in hist.iterrows():
+                    close = row.get('Close')
+                    if close is None or (isinstance(close, float) and close != close):
+                        continue
+                    records.append(PriceHistory(
+                        isin=isin,
+                        market_date=ts.date(),
+                        close_price=float(close),
+                    ))
+                if not records:
+                    log.warning('%s no valid close prices in history', progress)
+                    failed += 1
+                    continue
+                loaded = ETLBase.load_records(records)
+                if loaded > 0:
+                    fetched += 1
+                    log.info('%s loaded %s monthly bars', progress, loaded)
+                else:
+                    failed += 1
+                    log.warning('%s failed to persist price history', progress)
+            except Exception as e:
+                log.exception('%s fetch failed: %s', progress, e)
+                failed += 1
+                continue
+            time.sleep(0.1)
+
+        logger.info(
+            'Price history ETL complete: %s fetched, %s failed (of %s)',
+            fetched, failed, total,
+        )

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -26,6 +26,7 @@ const PRESET_SORT: Record<PresetId, SortingState> = {
   piotroski: [{ id: 'p_score', desc: true }],
   magic: [{ id: 'magic_formula_score', desc: true }],
   value: [{ id: 'shareholder_yield_total', desc: true }],
+  momentum: [{ id: 'momentum_score', desc: true }],
   all: [{ id: 'magic_formula_score', desc: true }],
 };
 
@@ -35,6 +36,7 @@ const PRIMARY_METRIC: Record<PresetId, { key: keyof Stock; label: string; type: 
   piotroski: { key: 'p_score', label: 'Piotroski', type: 'score' },
   magic: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
   value: { key: 'shareholder_yield_total', label: 'SH Yield', type: 'pct' },
+  momentum: { key: 'momentum_score', label: 'Momentum', type: 'pct' },
   all: { key: 'magic_formula_score', label: 'Magic F', type: 'num' },
 };
 

--- a/web/app/src/columns.tsx
+++ b/web/app/src/columns.tsx
@@ -180,6 +180,58 @@ export const columns = [
     sortUndefined: 'last',
     size: 90,
   }),
+  ch.accessor(num('momentum_score'), {
+    id: 'momentum_score',
+    header: 'Momentum',
+    cell: (info) => (
+      <ValueWithRank
+        value={info.getValue()}
+        formatted={fmtPercent(info.getValue())}
+        percentile={info.row.original.momentum_score_percentile}
+      />
+    ),
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    size: 170,
+  }),
+  ch.accessor(num('return_12_1'), {
+    id: 'return_12_1',
+    header: '12-1m Return',
+    cell: (info) => fmtPercent(info.getValue()),
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    size: 130,
+  }),
+  ch.accessor(num('return_6m'), {
+    id: 'return_6m',
+    header: '6m Return',
+    cell: (info) => fmtPercent(info.getValue()),
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    size: 110,
+  }),
+  ch.accessor(num('return_3m'), {
+    id: 'return_3m',
+    header: '3m Return',
+    cell: (info) => fmtPercent(info.getValue()),
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    size: 110,
+  }),
+  ch.accessor(num('value_momentum_score'), {
+    id: 'value_momentum_score',
+    header: 'Value + Momentum',
+    cell: (info) => {
+      const v = info.getValue();
+      if (v === null || v === undefined || Number.isNaN(v)) {
+        return <span className="muted">–</span>;
+      }
+      return <span className={`rank-pill rank-${rankTone(v)}`}>p{Math.round(v)}</span>;
+    },
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    size: 160,
+  }),
   ch.accessor(num('shareholder_yield_total'), {
     id: 'shareholder_yield_total',
     header: 'SH Yield (total)',
@@ -306,6 +358,8 @@ export const presets: Record<PresetId, { label: string; visible: string[] }> = {
       'sector',
       'p_score',
       'magic_formula_score',
+      'momentum_score',
+      'value_momentum_score',
       'roic',
       'ev_ebitda_ratio',
       'price',
@@ -320,6 +374,8 @@ export const presets: Record<PresetId, { label: string; visible: string[] }> = {
       'sector',
       'p_score',
       'magic_formula_score',
+      'momentum_score',
+      'value_momentum_score',
       'roic',
       'ev_ebitda_ratio',
       'price',
@@ -363,6 +419,21 @@ export const presets: Record<PresetId, { label: string; visible: string[] }> = {
       'ncav_ratio',
       'shareholder_yield_total',
       'trailing_pe',
+      'cap_tier',
+    ],
+  },
+  momentum: {
+    label: 'Momentum',
+    visible: [
+      'company_name',
+      'sector',
+      'momentum_score',
+      'return_12_1',
+      'return_6m',
+      'return_3m',
+      'value_momentum_score',
+      'price',
+      'market_cap_eur',
       'cap_tier',
     ],
   },

--- a/web/app/src/types.ts
+++ b/web/app/src/types.ts
@@ -32,6 +32,13 @@ export interface Stock {
   magic_formula_score_percentile: number | null;
   roic_percentile: number | null;
   shareholder_yield_percentile: number | null;
+  momentum_date: string | null;
+  return_12_1: number | null;
+  return_6m: number | null;
+  return_3m: number | null;
+  momentum_score: number | null;
+  momentum_score_percentile: number | null;
+  value_momentum_score: number | null;
 }
 
 export interface DataPayload {
@@ -39,4 +46,4 @@ export interface DataPayload {
   rows: Stock[];
 }
 
-export type PresetId = 'top_picks' | 'overview' | 'piotroski' | 'magic' | 'value' | 'all';
+export type PresetId = 'top_picks' | 'overview' | 'piotroski' | 'magic' | 'value' | 'momentum' | 'all';


### PR DESCRIPTION
Computes classic 12-1, 6-month, and 3-month total returns from monthly
yfinance close prices, plus an equal-weighted momentum composite. A new
PriceHistory model + StockPriceHistoryETL fetches ~14 months of monthly
bars per stock. Adds a Momentum preset to the frontend and a
value_momentum_score that averages the magic-formula and momentum
percentile ranks, so users can screen for stocks scoring well on both
factors.

https://claude.ai/code/session_01CTTPENrTmsVRh9NgXNrWEL