### PR TITLE
Add screener info modal explaining each screening strategy

### DIFF
--- a/web/app/src/components/ScreenerInfo.tsx
+++ b/web/app/src/components/ScreenerInfo.tsx
@@ -1,0 +1,212 @@
+import { useEffect } from 'react';
+
+interface ScreenerInfoProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ScreenerInfo({ open, onClose }: ScreenerInfoProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal-backdrop"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="screener-info-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="modal-header">
+          <h2 id="screener-info-title">How the screeners work</h2>
+          <button
+            type="button"
+            className="btn btn-ghost modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="modal-body">
+          <p className="modal-intro">
+            This screener combines several classic value-investing strategies. Each preset
+            highlights a different lens on the same Nordic universe. Scores are recomputed
+            from the latest annual filings; <code>null</code> values mean the underlying
+            data was missing.
+          </p>
+
+          <section className="info-section">
+            <h3>Piotroski F-Score</h3>
+            <p>
+              A 9-point checklist developed by Joseph Piotroski (2000) to separate financially
+              strong companies from weak ones. One point is awarded for each of the nine tests
+              the company passes — higher is better. Generally <strong>7-9 is strong</strong>,
+              <strong> 4-6 is mixed</strong>, and <strong>0-3 is weak</strong>.
+            </p>
+            <p className="info-subtle">Profitability (4 points):</p>
+            <ul>
+              <li>Positive return on assets (net income / total assets)</li>
+              <li>Positive operating cash flow</li>
+              <li>ROA improved year-over-year</li>
+              <li>Operating cash flow exceeds net income (earnings quality)</li>
+            </ul>
+            <p className="info-subtle">Leverage, liquidity &amp; funding (3 points):</p>
+            <ul>
+              <li>Long-term debt decreased year-over-year</li>
+              <li>Current ratio improved year-over-year</li>
+              <li>No new shares issued (net buyback or flat)</li>
+            </ul>
+            <p className="info-subtle">Operating efficiency (2 points):</p>
+            <ul>
+              <li>Gross margin improved year-over-year</li>
+              <li>Asset turnover (revenue / avg total assets) improved year-over-year</li>
+            </ul>
+          </section>
+
+          <section className="info-section">
+            <h3>Magic Formula</h3>
+            <p>
+              Joel Greenblatt's <em>The Little Book That Beats the Market</em> ranks companies
+              by combining <strong>quality</strong> (return on invested capital) with{' '}
+              <strong>cheapness</strong> (earnings yield). Higher is better.
+            </p>
+            <p className="info-formula">
+              <code>magic_formula_score = ROIC × (EBITDA / EV)</code>
+            </p>
+            <ul>
+              <li>
+                <strong>ROIC</strong> = NOPAT / avg invested capital, where{' '}
+                <code>NOPAT = EBIT × (1 − tax rate)</code> and invested capital excludes cash
+                and non-operating assets.
+              </li>
+              <li>
+                <strong>EBITDA / EV</strong> is the earnings yield (the inverse of EV/EBITDA).
+              </li>
+              <li>
+                Scores are <code>null</code> when both factors are negative — the multiplication
+                would otherwise flip sign and look attractive.
+              </li>
+            </ul>
+          </section>
+
+          <section className="info-section">
+            <h3>Value metrics</h3>
+            <p>
+              Classic valuation ratios shown in the <em>Value</em> preset. These are not
+              composite scores — each is a single number you can sort and filter on.
+            </p>
+            <ul>
+              <li>
+                <strong>P/E (TTM &amp; fwd)</strong> — price / earnings per share. Lower is
+                cheaper, but watch for negative or one-off earnings.
+              </li>
+              <li>
+                <strong>P/Sales</strong> = market cap / total revenue. Useful when earnings are
+                noisy.
+              </li>
+              <li>
+                <strong>P/CF</strong> = market cap / cash from operations. Less manipulable
+                than P/E.
+              </li>
+              <li>
+                <strong>EV/EBITDA</strong> — enterprise value / EBITDA. Capital-structure
+                neutral; comparable across debt levels.
+              </li>
+              <li>
+                <strong>NCAV ratio</strong> = (current assets − total liabilities) / market
+                cap. Benjamin Graham's "net-net" metric — values above 1 mean the company
+                trades below its liquidation value.
+              </li>
+              <li>
+                <strong>Shareholder yield</strong> = buyback yield + dividend yield.
+                <ul>
+                  <li>
+                    <em>Stock</em> = (prev common stock − current common stock) / prev common
+                    stock
+                  </li>
+                  <li>
+                    <em>Dividend</em> = |dividends paid| / market cap
+                  </li>
+                  <li>
+                    <em>Total</em> = stock + dividend, treating missing components as 0 when
+                    at least one side is reported.
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </section>
+
+          <section className="info-section">
+            <h3>Top Picks buckets</h3>
+            <p>
+              The <em>Top Picks</em> tab groups the top 5 stocks in three styles, applied
+              after your current filters:
+            </p>
+            <ul>
+              <li>
+                <strong>Quality</strong> — Piotroski F-Score ≥ 7 and ROIC &gt; 10%, ranked by
+                ROIC.
+              </li>
+              <li>
+                <strong>Value</strong> — Greenblatt's Magic Formula with F-Score ≥ 5 and
+                positive ROIC, ranked by Magic Formula score.
+              </li>
+              <li>
+                <strong>Deep Value</strong> — Graham-style net-nets (NCAV ratio &gt; 1) or
+                low-multiple contrarians (P/E ≤ 10, F-Score ≥ 5).
+              </li>
+            </ul>
+          </section>
+
+          <section className="info-section">
+            <h3>Rank pills &amp; percentiles</h3>
+            <p>
+              Coloured pills next to ROIC, Magic Formula, and Shareholder Yield show where the
+              value sits in the full Nordic universe (<code>p80</code> = better than 80% of
+              stocks). Pills are computed before filtering, so the ranking is stable as you
+              adjust filters.
+            </p>
+          </section>
+
+          <section className="info-section info-caveats">
+            <h3>Caveats</h3>
+            <ul>
+              <li>
+                Data comes from Yahoo Finance via <code>yfinance</code>. Field labels and
+                coverage vary by ticker — missing values are common for micro-caps.
+              </li>
+              <li>
+                Scores are based on the most recent annual filing only; trailing-twelve-month
+                figures come from price/valuation snapshots.
+              </li>
+              <li>
+                These are screening tools, not buy recommendations. Always read the filings
+                before acting on a result.
+              </li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/src/components/Toolbar.tsx
+++ b/web/app/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { CapTier, PresetId } from '../types';
 import { presets } from '../columns';
+import { ScreenerInfo } from './ScreenerInfo';
 
 export interface Filters {
   capTiers: Set<CapTier>;
@@ -93,6 +94,7 @@ export function Toolbar({
   columnPicker,
 }: ToolbarProps) {
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   const update = <K extends keyof Filters>(key: K, value: Filters[K]) =>
     onFilters({ ...filters, [key]: value });
@@ -114,6 +116,15 @@ export function Toolbar({
           <span className="generation-date">Updated {generatedAt}</span>
         </div>
         <div className="toolbar-actions">
+          <button
+            className="btn btn-ghost btn-icon"
+            onClick={() => setInfoOpen(true)}
+            aria-label="About the screeners"
+            title="About the screeners"
+          >
+            <span aria-hidden="true" className="info-glyph">i</span>
+            <span className="btn-icon-label">Info</span>
+          </button>
           <button
             className="btn btn-ghost"
             onClick={() => setFiltersOpen((v) => !v)}
@@ -279,6 +290,8 @@ export function Toolbar({
           </div>
         </div>
       )}
+
+      <ScreenerInfo open={infoOpen} onClose={() => setInfoOpen(false)} />
     </header>
   );
 }

--- a/web/app/src/styles.css
+++ b/web/app/src/styles.css
@@ -137,6 +137,30 @@ body {
 }
 .btn-ghost:hover { border-color: var(--text-muted); }
 
+.btn-icon {
+  padding: 8px 12px;
+}
+.info-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  font-style: italic;
+  font-family: "Georgia", "Times New Roman", serif;
+  line-height: 1;
+}
+.btn-icon-label { font-size: 13px; }
+@media (max-width: 768px) {
+  .btn-icon-label { display: none; }
+  .btn-icon { padding: 8px 10px; }
+}
+
 .toolbar-search {
   margin-top: 10px;
   display: flex;
@@ -768,6 +792,166 @@ body {
   text-decoration: none;
 }
 .site-footer a:hover { color: var(--text); }
+
+/* ---------- Modal (screener info) ---------- */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 22, 45, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 40px 16px;
+  z-index: 100;
+  overflow-y: auto;
+  backdrop-filter: blur(2px);
+  animation: modal-fade 120ms ease-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  .modal-backdrop { background: rgba(0, 0, 0, 0.6); }
+}
+
+@keyframes modal-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.modal {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  max-width: 720px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 80px);
+  animation: modal-rise 160ms ease-out;
+}
+
+@keyframes modal-rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.modal-close {
+  padding: 4px 10px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.modal-body {
+  padding: 16px 20px 24px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.modal-intro {
+  margin: 0 0 18px;
+  color: var(--text-muted);
+}
+
+.info-section {
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+}
+.info-section:first-of-type { border-top: none; padding-top: 0; }
+
+.info-section h3 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.info-section p {
+  margin: 0 0 8px;
+}
+
+.info-section ul {
+  margin: 4px 0 8px;
+  padding-left: 20px;
+}
+.info-section ul ul {
+  margin-top: 4px;
+}
+
+.info-section li {
+  margin-bottom: 4px;
+}
+
+.info-section code {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 12px;
+  font-family: "SF Mono", "Menlo", "Consolas", monospace;
+}
+
+.info-subtle {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  margin-top: 8px !important;
+  margin-bottom: 2px !important;
+}
+
+.info-formula {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 6px 0 10px !important;
+  text-align: center;
+}
+.info-formula code {
+  background: transparent;
+  border: none;
+  font-size: 13px;
+}
+
+.info-caveats {
+  background: var(--surface-2);
+  margin: 14px -20px -24px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 var(--radius) var(--radius);
+}
+
+@media (max-width: 768px) {
+  .modal-backdrop { padding: 16px 8px; }
+  .modal { max-height: calc(100vh - 32px); }
+  .modal-header { padding: 14px 16px; }
+  .modal-body { padding: 14px 16px 20px; }
+  .info-caveats { margin: 14px -16px -20px; padding: 14px 16px 16px; }
+}
 
 /* ---------- Mobile tweaks ---------- */
 


### PR DESCRIPTION
A new "Info" button in the toolbar opens a modal that walks users
through what each preset measures and how the scores are computed —
Piotroski F-Score (all 9 tests), Magic Formula (ROIC × earnings yield),
the value ratios, NCAV, shareholder yield, and the Top Picks buckets.

https://claude.ai/code/session_01YcTdXFvanKno92Pgi3by6s