### PR TITLE
Update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # Nordic Stock Screener
 
-A stock screener for Nasdaq OMX Nordic exchanges, running as a GitHub Actions job that produces a static website with an accompanying SQLite database.
+A stock screener for Nordic exchanges (Stockholm, Copenhagen, Helsinki, Oslo), running as a weekly GitHub Actions job that produces a static website with an accompanying SQLite database.
+
+**Live site: [lseffer.github.io/stock_screener](https://lseffer.github.io/stock_screener/)**
+
+**Tech stack:** Python 3.12 | SQLite | Polars | React + TypeScript + TanStack Table | Vite
 
 ![](app_screenshot.png?raw=true)
 
@@ -16,10 +20,10 @@ A stock screener for Nasdaq OMX Nordic exchanges, running as a GitHub Actions jo
 
 The screener runs as a scheduled GitHub Actions workflow that:
 
-1. **Scrapes** stock listings from Nasdaq OMX Nordic exchanges
-2. **Fetches** financial data (prices, statements) via [yfinance](https://github.com/ranaroussi/yfinance)
-3. **Computes** Piotroski F-Score and Magic Formula screening scores
-4. **Stores** all data in a SQLite database
+1. **Discovers** stock listings from Nordic exchanges via the [yfinance](https://github.com/ranaroussi/yfinance) screener API
+2. **Fetches** financial data (prices, income statements, balance sheets, cash flows) via yfinance
+3. **Computes** Piotroski F-Score and Magic Formula screening scores using Polars
+4. **Stores** all data in a SQLite database (incremental — only updates stale records)
 5. **Generates** a static website with the screening results
 6. **Deploys** to GitHub Pages
 
@@ -45,10 +49,32 @@ Output:
 - `_site/stocks.db` - SQLite database with all raw + computed data
 - `stocks.db` - Working database
 
+### Frontend development
+
+```bash
+# Build the frontend (one-time or when frontend changes)
+(cd web/app && npm ci && npm run build)
+
+# For live reload during frontend development:
+# 1. Generate data first
+python generate_site.py --skip-etl
+
+# 2. Copy data into the dev server's public dir and start Vite
+cp _site/data.json web/app/public/data.json
+cd web/app && npm run dev
+```
+
+### Environment variables
+
+All optional:
+- `STOCK_SCREENER_DB` — SQLite path (default: `stocks.db`)
+- `STOCK_SCREENER_OUTPUT` — site output dir (default: `_site`)
+
 ## Data sources
 
-- **Stock listings**: Scraped from [Nasdaq OMX Nordic](https://www.nasdaqomxnordic.com/) (Copenhagen, Helsinki, Stockholm, First North, Norwegian)
-- **Financial data**: [yfinance](https://github.com/ranaroussi/yfinance) (prices, income statements, balance sheets, cash flows)
+All data is fetched via [yfinance](https://github.com/ranaroussi/yfinance):
+- **Stock listings**: Discovered using the yfinance screener API (`EquityQuery` by exchange) for Stockholm, Copenhagen, Helsinki, and Oslo
+- **Financial data**: Prices, income statements, balance sheets, and cash flows via `yfinance.Ticker`
 
 ## Running tests
 


### PR DESCRIPTION
Add live GitHub Pages link, tech stack summary, frontend dev
instructions, environment variables, and update data source
descriptions to reflect the yfinance screener API (replacing the
old Nasdaq OMX Nordic scraper references).

https://claude.ai/code/session_01GGn5H2NCUWYxuDzTtEdjZ8