### PR TITLE
Add Piotroski F-Score breakdown popover showing all 9 criteria

### DIFF
--- a/scoring.py
+++ b/scoring.py
@@ -353,6 +353,8 @@ def compute_screen_results() -> pl.DataFrame:
     output_cols = [
         'isin', 'company_name', 'symbol', 'currency', 'sector', 'yahoo_ticker',
         'report_date', 'market_date', 'p_score',
+        'p_score_1', 'p_score_2', 'p_score_3', 'p_score_4', 'p_score_5',
+        'p_score_6', 'p_score_7', 'p_score_8', 'p_score_9',
         'roic', 'ev_ebitda_ratio_inv', 'shareholder_yield_stock',
         'shareholder_yield_dividends', 'shareholder_yield_total',
         'price_to_sales', 'price_to_cash_flow',

--- a/web/app/src/columns.tsx
+++ b/web/app/src/columns.tsx
@@ -1,4 +1,6 @@
 import { createColumnHelper } from '@tanstack/react-table';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import type { Stock, PresetId, CapTier } from './types';
 import { fmtCompact, fmtDecimal, fmtEUR, fmtPercent, fmtPrice, fmtText } from './format';
 
@@ -50,6 +52,81 @@ function ValueWithRank({
   );
 }
 
+export const PIOTROSKI_CRITERIA: { key: keyof Stock; label: string }[] = [
+  { key: 'p_score_1', label: 'Positive ROA' },
+  { key: 'p_score_2', label: 'Positive Cash Flow' },
+  { key: 'p_score_3', label: 'Improving ROA' },
+  { key: 'p_score_4', label: 'Earnings Quality' },
+  { key: 'p_score_5', label: 'Lower Leverage' },
+  { key: 'p_score_6', label: 'Improving Liquidity' },
+  { key: 'p_score_7', label: 'No Share Dilution' },
+  { key: 'p_score_8', label: 'Improving Gross Margin' },
+  { key: 'p_score_9', label: 'Improving Asset Turnover' },
+];
+
+function PiotroskiBreakdown({ stock }: { stock: Stock }) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+
+  const updatePos = useCallback(() => {
+    if (!btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    setPos({ top: rect.bottom + 6, left: rect.left + rect.width / 2 });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    updatePos();
+    const handler = (e: MouseEvent) => {
+      if (
+        popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
+        btnRef.current && !btnRef.current.contains(e.target as Node)
+      ) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, updatePos]);
+
+  const v = stock.p_score;
+  if (v === null || v === undefined) return <span className="muted">–</span>;
+  const tone = v >= 7 ? 'good' : v >= 5 ? 'mid' : 'bad';
+
+  return (
+    <div className="piotroski-wrap">
+      <button
+        ref={btnRef}
+        className={`pill pill-${tone} pill-clickable`}
+        onClick={(e) => { e.stopPropagation(); setOpen(!open); }}
+      >
+        {v}
+      </button>
+      {open && createPortal(
+        <div
+          ref={popoverRef}
+          className="piotroski-popover"
+          style={{ top: pos.top, left: pos.left }}
+        >
+          <div className="piotroski-popover-title">Piotroski F-Score: {v}/9</div>
+          <ul className="piotroski-list">
+            {PIOTROSKI_CRITERIA.map(({ key, label }) => {
+              const pass = stock[key] === 1;
+              return (
+                <li key={key} className={pass ? 'p-pass' : 'p-fail'}>
+                  <span className="p-icon">{pass ? '✓' : '✗'}</span>
+                  <span>{label}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}
+
 const CAP_TIER_LABEL: Record<CapTier, string> = {
   large: 'Large',
   mid: 'Mid',
@@ -95,12 +172,7 @@ export const columns = [
   ch.accessor(num('p_score'), {
     id: 'p_score',
     header: 'Piotroski',
-    cell: (info) => {
-      const v = info.getValue();
-      if (v === null) return <span className="muted">–</span>;
-      const tone = v >= 7 ? 'good' : v >= 5 ? 'mid' : 'bad';
-      return <span className={`pill pill-${tone}`}>{v}</span>;
-    },
+    cell: (info) => <PiotroskiBreakdown stock={info.row.original} />,
     sortingFn: 'basic',
     size: 110,
   }),

--- a/web/app/src/components/StockCards.tsx
+++ b/web/app/src/components/StockCards.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Stock } from '../types';
 import { fmtCompact, fmtDecimal, fmtEUR, fmtPercent, fmtPrice, fmtText } from '../format';
+import { PIOTROSKI_CRITERIA } from '../columns';
 
 function rankTone(p: number): string {
   if (p >= 80) return 'top';
@@ -41,7 +42,7 @@ interface StockCardsProps {
 }
 
 const CARD_HEIGHT = 132;
-const EXPANDED_EXTRA = 220;
+const EXPANDED_EXTRA = 320;
 
 function formatMetric(value: unknown, type: 'pct' | 'num' | 'score'): string {
   if (typeof value !== 'number' || Number.isNaN(value)) return '–';
@@ -170,6 +171,22 @@ export function StockCards({ rows, primaryMetric }: StockCardsProps) {
                       <Stat label="Analysts" value={fmtDecimal(stock.number_of_analyst_opinions)} />
                       <Stat label="Report" value={fmtText(stock.report_date)} />
                     </div>
+                    {stock.p_score !== null && (
+                      <div className="piotroski-breakdown-inline">
+                        <div className="piotroski-popover-title">Piotroski Breakdown</div>
+                        <ul className="piotroski-list">
+                          {PIOTROSKI_CRITERIA.map(({ key, label }) => {
+                            const pass = stock[key] === 1;
+                            return (
+                              <li key={key} className={pass ? 'p-pass' : 'p-fail'}>
+                                <span className="p-icon">{pass ? '✓' : '✗'}</span>
+                                <span>{label}</span>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    )}
                     <a
                       className="card-link"
                       href={`https://www.google.com/search?q=${encodeURIComponent(

--- a/web/app/src/styles.css
+++ b/web/app/src/styles.css
@@ -484,6 +484,84 @@ body {
 
 .muted { color: var(--text-muted); }
 
+/* ---------- Piotroski breakdown popover ---------- */
+
+.piotroski-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.pill-clickable {
+  cursor: pointer;
+  border: none;
+  font-family: inherit;
+}
+.pill-clickable:hover {
+  filter: brightness(0.92);
+}
+
+.piotroski-popover {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 100;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  padding: 10px 14px;
+  width: 220px;
+  animation: modal-fade 100ms ease-out;
+}
+
+.piotroski-popover-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.piotroski-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.piotroski-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.p-icon {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.p-pass { color: var(--pill-good-fg); }
+.p-fail { color: var(--text-muted); opacity: 0.7; }
+.p-pass .p-icon { color: var(--pill-good-fg); }
+.p-fail .p-icon { color: var(--pill-bad-fg); }
+
+.piotroski-breakdown-inline {
+  padding: 8px 14px 4px;
+  border-top: 1px solid var(--border);
+}
+.piotroski-breakdown-inline .piotroski-popover-title {
+  margin-bottom: 6px;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
 /* ---------- Column picker ---------- */
 
 .column-picker {

--- a/web/app/src/types.ts
+++ b/web/app/src/types.ts
@@ -10,6 +10,15 @@ export interface Stock {
   report_date: string | null;
   market_date: string | null;
   p_score: number | null;
+  p_score_1: number | null;
+  p_score_2: number | null;
+  p_score_3: number | null;
+  p_score_4: number | null;
+  p_score_5: number | null;
+  p_score_6: number | null;
+  p_score_7: number | null;
+  p_score_8: number | null;
+  p_score_9: number | null;
   roic: number | null;
   ev_ebitda_ratio_inv: number | null;
   shareholder_yield_stock: number | null;


### PR DESCRIPTION
Users can now click the Piotroski score pill to see which of the 9
criteria (positive ROA, cash flow quality, leverage, etc.) pass or fail
for each stock. On mobile cards, the breakdown appears inline in the
expanded detail section.

https://claude.ai/code/session_015JJReSN1EgEyQQnS3vcCCy