### PR TITLE
Fix overlapping stock cards on expand/collapse

### DIFF
--- a/web/app/src/components/StockCards.tsx
+++ b/web/app/src/components/StockCards.tsx
@@ -76,7 +76,11 @@ export function StockCards({ rows, primaryMetric }: StockCardsProps) {
       else next.add(isin);
       return next;
     });
-    requestAnimationFrame(() => virtualizer.measure());
+    // Don't call virtualizer.measure() here: it resets the entire measurement
+    // cache back to estimateSize, and the already-mounted cards won't re-fire
+    // their ResizeObserver, so their real heights are lost and the absolutely
+    // positioned cards overlap. measureElement already re-measures the card
+    // that grew/shrank and recomputes every offset on its own.
   };
 
   if (rows.length === 0) {


### PR DESCRIPTION
The mobile card list uses TanStack Virtual's dynamic measurement
(measureElement), but toggle() also called virtualizer.measure(), which
resets the entire measurement cache back to estimateSize. The already
mounted cards don't change size from that reset, so their ResizeObserver
never re-fires and their real heights are lost, leaving every card at the
132px estimate. Since collapsed cards are taller than that, the absolutely
positioned cards overlapped ("stacked on top of each other").

Remove the manual measure() call and let measureElement re-measure the
card that grew/shrank and recompute the offsets on its own.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019homnryPta7QrpTfa1edxs